### PR TITLE
Preserve primitives when cloning directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@
    */
 
   return function (target) {
-    if (typeof target === 'number' || typeof target === 'string' || typeof target === 'boolean') {
-      return target;
+    if (/number|string|boolean/.test(typeof target)) {
+      return target
     }
     var copy = (target instanceof Array) ? [] : {}
     ;(function read (target, copy) {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@
    */
 
   return function (target) {
+    if (typeof target === 'number' || typeof target === 'string' || typeof target === 'boolean') {
+      return target;
+    }
     var copy = (target instanceof Array) ? [] : {}
     ;(function read (target, copy) {
       for (var key in target) {

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,21 @@ describe('deep-copy', function () {
     t.deepEqual(copy[2].b, {d: 15})
   })
 
+  it('preserve numbers', function () {
+    var copy = dcopy(42)
+    t.deepEqual(copy, 42)
+  })
+
+  it('preserve strings', function () {
+    var copy = dcopy("a")
+    t.deepEqual(copy, "a")
+  })
+
+  it('preserve booleans', function () {
+    var copy = dcopy(true)
+    t.deepEqual(copy, true)
+  })
+
   it('preserve functions', function () {
     var copy = dcopy(obj)
     t.ok(typeof obj.d === 'function')

--- a/test/index.js
+++ b/test/index.js
@@ -44,8 +44,8 @@ describe('deep-copy', function () {
   })
 
   it('preserve strings', function () {
-    var copy = dcopy("a")
-    t.deepEqual(copy, "a")
+    var copy = dcopy('a')
+    t.deepEqual(copy, 'a')
   })
 
   it('preserve booleans', function () {


### PR DESCRIPTION
Eg. should: deepCopy(42) === 42

This is especially useful when using deepCopy in a situation where the identity of an object is unknown. 